### PR TITLE
Adding Digital Commowealth and Leventhal Map & Education Center

### DIFF
--- a/guides/digitalcommonwealth.org/index.md
+++ b/guides/digitalcommonwealth.org/index.md
@@ -1,0 +1,27 @@
+---
+title: Digital Commonwealth
+consortium: yes 
+homepage: https://digitalcommonwealth.org
+layout: guide
+---
+
+Add the suffix `/manifest` to the end of a digitalcommonwealth.org record URL to retrieve the Presentation 2.0 Manifest
+
+**Example**
+
+* Digital Commonwealth URL: https://www.digitalcommonwealth.org/search/commonwealth:668305767
+* Manifest: https://www.digitalcommonwealth.org/search/commonwealth:668305767/manifest
+
+
+### Leventhal Map & Education Center
+
+The Leventhal Map & Education Center [Digital Collections portal](https://collections.leventhalmap.org) is a custom view of Digital Commonwealth, and follows the same syntax for Manifest URLs.
+
+**Example**
+
+* LMEC Digital Collections URL: https://collections.leventhalmap.org/search/commonwealth:x059cb10w
+* Manifest: https://collections.leventhalmap.org/search/commonwealth:x059cb10w/manifest
+
+### See also 
+
+* [Digital Commonwealth API documentation](https://www.digitalcommonwealth.org/api)

--- a/guides/digitalcommonwealth.org/index.md
+++ b/guides/digitalcommonwealth.org/index.md
@@ -9,8 +9,8 @@ Add the suffix `/manifest` to the end of a digitalcommonwealth.org record URL to
 
 **Example**
 
-* Digital Commonwealth URL: https://www.digitalcommonwealth.org/search/commonwealth:668305767
-* Manifest: https://www.digitalcommonwealth.org/search/commonwealth:668305767/manifest
+* Digital Commonwealth URL: [https://www.digitalcommonwealth.org/search/commonwealth:668305767](https://www.digitalcommonwealth.org/search/commonwealth:668305767)
+* Manifest: [https://www.digitalcommonwealth.org/search/commonwealth:668305767/manifest](https://www.digitalcommonwealth.org/search/commonwealth:668305767/manifest)
 
 
 ### Leventhal Map & Education Center
@@ -19,8 +19,8 @@ The Leventhal Map & Education Center [Digital Collections portal](https://collec
 
 **Example**
 
-* LMEC Digital Collections URL: https://collections.leventhalmap.org/search/commonwealth:x059cb10w
-* Manifest: https://collections.leventhalmap.org/search/commonwealth:x059cb10w/manifest
+* LMEC Digital Collections URL: [https://collections.leventhalmap.org/search/commonwealth:x059cb10w](https://collections.leventhalmap.org/search/commonwealth:x059cb10w)
+* Manifest: [https://collections.leventhalmap.org/search/commonwealth:x059cb10w/manifest](https://collections.leventhalmap.org/search/commonwealth:x059cb10w/manifest)
 
 ### See also 
 


### PR DESCRIPTION
Taking @garrettdashnelson changes and making links clickable. As the branch is also on the IIIF github it should generate the preview link.