### PR TITLE
Make Leiden University URL https

### DIFF
--- a/guides/universiteitleiden.nl/index.md
+++ b/guides/universiteitleiden.nl/index.md
@@ -3,7 +3,7 @@ title: Leiden University
 # One of: no, full or associate
 consortium: full 
 # URL to discovery system for IIIF Resources
-homepage: http://digitalcollections.universiteitleiden.nl/
+homepage: https://digitalcollections.universiteitleiden.nl/
 layout: guide
 ---
 


### PR DESCRIPTION
Make the homepage to Leiden University's Digital Collections an HTTPS URL.